### PR TITLE
Set up CI workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,22 @@
+name: Format
+
+on: [push, pull_request]
+
+jobs:
+
+  format:
+    name: Check for lint and format code to a standard style
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+
+      - name: Install nox
+        run: pip install nox
+
+      - name: Lint and format code
+        run: nox -s format -- --check --verbose --diff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Install NetLogo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9"]
+
+    steps:
+      - name: Install NetLogo
+        run: |
+          curl https://ccl.northwestern.edu/netlogo/6.1.1/NetLogo-6.1.1-64.tgz --output NetLogo-6.1.1-64.tgz
+          tar xf NetLogo-6.1.1-64.tgz
+          mv NetLogo\ 6.1.1 /opt/netlogo-6.1.1
+          ls -l /opt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
           miniforge-variant: Miniforge3
           miniforge-version: latest
           auto-update-conda: true
+          activate-environment: logo
+          environment-file: environment.yml
 
       - name: Install package
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Install NetLogo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
-          micromamba-version: latest
-          environment-file: environment.yml
+          python-version: ${{ matrix.python-version }}
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          auto-update-conda: true
 
       - name: Install package
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,23 @@ jobs:
           curl https://ccl.northwestern.edu/netlogo/6.1.1/NetLogo-6.1.1-64.tgz --output NetLogo-6.1.1-64.tgz
           tar xf NetLogo-6.1.1-64.tgz
           mv NetLogo\ 6.1.1 /opt/netlogo-6.1.1
-          ls -l /opt
+
+      - uses: actions/checkout@v4
+
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: latest
+          environment-file: environment.yml
+
+      - name: Install package
+        run: |
+          pip install -e .
+
+      - name: Test
+        run: |
+          nox -s test --python ${{ matrix.python-version }}
+  
+      - name: Run examples
+        working-directory: ${{ github.workspace }}/examples
+        run: |
+          python run-bmi-model.py


### PR DESCRIPTION
This PR includes two CI workflows, *test* and *format*, that run on GitHub Actions.

The *test* workflow currently runs only on Linux. It's also limited to `python<3.12` because of its `jpype1` dependency.