### PR TITLE
Update continuous integration workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,6 +2,10 @@ name: Format
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
 
   format:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,13 +7,14 @@ jobs:
   format:
     name: Check for lint and format code to a standard style
     if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           nox -s test --python ${{ matrix.python-version }}
 
-      # Runs, passes all tests, but hangs at the end. A Java connection issue?
+      # Runs, passes all tests, but hangs at the end. This is https://github.com/csdms/bmi-example-pynetlogo/issues/1.
       # - name: Test BMI
       #   run: |
       #     nox -s test-bmi --python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,14 +36,10 @@ jobs:
           activate-environment: logo
           environment-file: environment.yml
 
-      - name: Install package
-        run: |
-          pip install -e .
-
       - name: Test
         run: |
           nox -s test --python ${{ matrix.python-version }}
-  
+
       - name: Run examples
         working-directory: ${{ github.workspace }}/examples
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           nox -s test --python ${{ matrix.python-version }}
 
+      - name: Test BMI
+        run: |
+          nox -s test-bmi --python ${{ matrix.python-version }}
+
       - name: Run examples
         working-directory: ${{ github.workspace }}/examples
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Install NetLogo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,7 @@ on: [push, pull_request]
 jobs:
   build-and-test:
     if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ${{ matrix.os }}
 
@@ -28,7 +27,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
           miniforge-variant: Miniforge3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install nox
+        run: pip install nox
+
       - name: Test
         run: |
           nox -s test --python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '43 4 3 * *'  # 4:43a on third day of the month
 
 jobs:
   build-and-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '43 4 3 * *'  # 4:43a on third day of the month
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     if:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Miniforge3
-          miniforge-version: latest
-          auto-update-conda: true
-          activate-environment: logo
-          environment-file: environment.yml
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,5 @@ jobs:
           nox -s test-bmi --python ${{ matrix.python-version }}
 
       - name: Run examples
-        working-directory: ${{ github.workspace }}/examples
         run: |
-          python run-bmi-model.py
+          nox -s run-examples --python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,8 @@ jobs:
       - name: Run examples
         run: |
           nox -s run-examples --python ${{ matrix.python-version }}
+
+      - name: Check Jupyter notebooks
+        if: ${{ matrix.python-version == '3.12' }}
+        run: |
+          nox -s check-notebooks --python="${{ matrix.python-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,10 @@ jobs:
         run: |
           nox -s test --python ${{ matrix.python-version }}
 
-      - name: Test BMI
-        run: |
-          nox -s test-bmi --python ${{ matrix.python-version }}
+      # Runs, passes all tests, but hangs at the end. A Java connection issue?
+      # - name: Test BMI
+      #   run: |
+      #     nox -s test-bmi --python ${{ matrix.python-version }}
 
       - name: Run examples
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include heat/HeatDiffusion.nlogo

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ This example can be built and installed on Linux, macOS, and Windows.
 
 **Prerequisites:**
 
+* Java Runtime Environment (JRE). NetLogo is build on Java, and it needs a JRE to run.
 * NetLogo. Instructions for downloading and installing NetLogo can be found [here](https://ccl.northwestern.edu/netlogo/download.shtml). NetLogo 6.1.1 was used to build, test, and run this example.
-* The Python BMI bindings. Follow the [build and install directions](https://github.com/csdms/bmi-python#install) given in that repository. You can choose to install them from source, or through `pip` or `conda`.
+* Python BMI mappings. Follow the [build and install directions](https://github.com/csdms/bmi-python#install) given in that repository. You can choose to install them from source, or through `pip` or `conda`.
 * PyNetLogo and Jpype. These are the key software packages that allow communication between NetLogo and Python.
 
 We recommend setting up a virtual environment--e.g., through `venv` or `conda`--to install the packages required for this example.
@@ -53,6 +54,18 @@ Install the example with `pip`.
 pip install -e .
 ```
 
+### Note on Java install location
+
+Jpype tries to guess where Java is installed.
+If Java is installed in a non-standard location,
+set the `JAVA_HOME` environment variable.
+As an example,
+I installed Java through Homebrew on my Mac,
+so I set `JAVA_HOME` to its install location:
+```bash
+export JAVA_HOME=/opt/homebrew/opt/openjdk
+```
+
 ## Use
 
 Try the example notebooks and scripts in the [examples](./examples/) directory. 
@@ -67,4 +80,4 @@ The NetLogo software.
 
 > Wilensky, U. (1999). NetLogo. http://ccl.northwestern.edu/netlogo/. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
 
-CSDMS is supported with funding from the National Science Foundation.
+CSDMS is supported with funding from the U.S. National Science Foundation.

--- a/examples/helpers.py
+++ b/examples/helpers.py
@@ -1,4 +1,5 @@
 """Helper functions for working with the HeatDiffusion model."""
+
 import matplotlib.pyplot as plt
 import numpy
 

--- a/examples/run-bmi-model.ipynb
+++ b/examples/run-bmi-model.ipynb
@@ -44,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "cat \"config.yaml\""
+    "!cat \"config.yaml\""
    ]
   },
   {
@@ -69,8 +69,7 @@
    },
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
+    "import numpy as np"
    ]
   },
   {

--- a/examples/run-model.ipynb
+++ b/examples/run-model.ipynb
@@ -50,7 +50,6 @@
    },
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import pynetlogo"
    ]

--- a/heat/__init__.py
+++ b/heat/__init__.py
@@ -1,4 +1,5 @@
 """Model the diffusion of heat over a 2D plate."""
+
 from ._version import __version__
 from .bmi_heatdiffusion import BmiHeatDiffusion
 

--- a/heat/bmi_heatdiffusion.py
+++ b/heat/bmi_heatdiffusion.py
@@ -19,7 +19,6 @@ BmiGridUniformRectilinear = namedtuple(
 
 
 class BmiHeatDiffusion(Bmi):
-
     """Solve the heat equation on a 2D plate."""
 
     _name = "The 2D Heat Equation"

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,10 +32,10 @@ def test(session: nox.Session) -> None:
         session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
-@nox.session(name="test-bmi", venv_backend="conda")
+@nox.session(name="test-bmi", python=PYTHON_VERSIONS)
 def test_bmi(session: nox.Session) -> None:
     """Test the Basic Model Interface."""
-    session.conda_install("bmi-tester")
+    session.install("bmi-tester")
     session.install(".")
     session.run(
         "bmi-test",

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ PACKAGE = "heat"
 HERE = pathlib.Path(__file__)
 ROOT = HERE.parent
 PATHS = [PACKAGE, "examples", "tests", HERE.name]
-PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
+PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,9 +41,9 @@ def test_bmi(session: nox.Session) -> None:
         "bmi-test",
         "heat:BmiHeatDiffusion",
         "--config-file",
-        "./examples/config.yaml",
+        f"{ROOT}/examples/config.yaml",
         "--root-dir",
-        "./examples",
+        "examples",
         "-vvv",
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,7 +60,7 @@ def format(session: nox.Session) -> None:
 
     session.run("black", *black_args, *PATHS)
     session.run("isort", *PATHS)
-    session.run("ruff", "--fix", *PATHS)
+    session.run("ruff", "check", "--fix", *PATHS)
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,7 @@ def test_bmi(session: nox.Session) -> None:
 def run_examples(session: nox.Session):
     """Run Python script examples."""
     session.install(".[examples]")
-    session.cd("examples")
+    session.cd(f"{ROOT}/examples")
     session.run("python", "run-bmi-model.py")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -48,6 +48,14 @@ def test_bmi(session: nox.Session) -> None:
     )
 
 
+@nox.session(name="run-examples", python=PYTHON_VERSIONS)
+def run_examples(session: nox.Session):
+    """Run Python script examples."""
+    session.install(".[examples]")
+    session.cd("examples")
+    session.run("python", "run-bmi-model.py")
+
+
 @nox.session
 def format(session: nox.Session) -> None:
     """Clean lint and assert style."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,6 +56,23 @@ def run_examples(session: nox.Session):
     session.run("python", "run-bmi-model.py")
 
 
+@nox.session(name="check-notebooks", python=PYTHON_VERSIONS)
+def check_notebooks(session: nox.Session) -> None:
+    """Run the example notebooks."""
+    session.install(".[testing,examples]")
+    session.install("nbmake")
+
+    args = [
+        "--nbmake",
+        "--nbmake-kernel=python3",
+        "--nbmake-timeout=3000",
+        "-vvv",
+    ] + session.posargs
+
+    session.cd(f"{ROOT}/examples")
+    session.run("pytest", *args)
+
+
 @nox.session
 def format(session: nox.Session) -> None:
     """Clean lint and assert style."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,14 @@ classifiers = [
   "Intended Audience :: Education",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3",
   "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "bmipy",
   "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ testpaths = ["heat", "tests"]
 norecursedirs = [".*", "*.egg*", "build", "dist"]
 addopts = """
   --tb native
-  --strict
+  --strict-markers
   --durations 16
   --doctest-modules
   -vvv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ line_length = 88
 
 [tool.ruff]
 line-length = 88
-ignore = [
+lint.ignore = [
 	"E203",
 	"E501",
 ]

--- a/tests/test_get_value.py
+++ b/tests/test_get_value.py
@@ -1,4 +1,5 @@
 """Test the BMI get_value functions."""
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,4 +1,5 @@
 """Test BMI model grid information functions."""
+
 import numpy as np
 from numpy.testing import assert_array_equal
 

--- a/tests/test_irf.py
+++ b/tests/test_irf.py
@@ -1,4 +1,5 @@
 """Test BMI model control functions."""
+
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
 

--- a/tests/test_model_info.py
+++ b/tests/test_model_info.py
@@ -1,4 +1,5 @@
 """Test BMI model information functions."""
+
 from heat import BmiHeatDiffusion
 
 

--- a/tests/test_set_value.py
+++ b/tests/test_set_value.py
@@ -1,4 +1,5 @@
 """Test the BMI get_value functions."""
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,4 +1,5 @@
 """Test BMI model time functions."""
+
 import numpy as np
 from numpy.testing import assert_almost_equal
 

--- a/tests/test_vars.py
+++ b/tests/test_vars.py
@@ -1,4 +1,5 @@
 """Test BMI model variable information functions."""
+
 from heat import BmiHeatDiffusion
 
 CONFIG_FILE = "config.yaml"


### PR DESCRIPTION
The motivation behind this PR was to add a scheduled monthly build to the *test* CI workflow. However, along the way, I found several other related things to update, including:

* Drop Python 3.9, add 3.13
* Make CI workflows cancelable
* Minimize the use of *conda* in favor of *venv*
* Add a *nox* session to run scripts in the `examples` directory
* Add a *nox* session to check the example notebooks with *nbmake*
* Use a manifest file to include the NetLogo model source in the project install
* Remove lint